### PR TITLE
Plugin API: Hook missing for the templates

### DIFF
--- a/controller/class.HackademicController.php
+++ b/controller/class.HackademicController.php
@@ -135,7 +135,12 @@ abstract class HackademicController {
 	 * @param $tmpl str Template name
 	 */
 	public function setViewTemplate($tmpl) {
-		$this->view_template = $this->smarty->user_theme_path . $tmpl;
+		$path = $this->smarty->user_theme_path . $tmpl;
+		$new_path = Plugin::apply_filters_ref_array('set_view_template', array($path));
+		if($new_path != '') {
+			$path = $new_path;
+		}
+		$this->view_template = HACKADEMIC_PATH . $path;
 	}
 
 	/**


### PR DESCRIPTION
I've started to develop the new clue plugin using the [plugin API](https://github.com/Hackademic/hackademic/blob/gsoc2013/docs/) (#41) from last summer GSoC.

In order to display the clues to the students I need to change the template for the view which displays the challenge (normally [showChallenge.tpl](https://github.com/Hackademic/hackademic/blob/next/view/showChallenge.tpl)). I can't find a hook in the plugin API to do this.

I had the same need with the admin views ([editchallenge.tpl](https://github.com/Hackademic/hackademic/blob/next/admin/view/editchallenge.tpl) for example) and the hook `set_admin_view_template` solved it quite easily.

I just need to know if it's really missing or if I missed something. Or maybe there is a reason for that. @span Any insight on this?
If it's just missing I can add it. If I follow the way it's done for the admin views it shouldn't be difficult :)
