### PR TITLE
Installation process: detect connection errors with mysqli

### DIFF
--- a/installation/installer/Installer.php
+++ b/installation/installer/Installer.php
@@ -241,7 +241,7 @@ class Installer
 			returns a connection error. Since we will CREATE IF NOT EXISTS, and then USE the database we don't provide
 			a dbname here*/
 		$link = new mysqli($this->_options['dbhost'], $this->_options['dbuser'], $this->_options['dbpass']);
-		if(!$link) {
+		if(!$link || $link->connect_errno) {
 			$this->view->error($this->lang['L-04']);
 		}
 		


### PR DESCRIPTION
This pull request fixes a small bug during the installation process. Currently, if we enter incorrect authentication parameters for the MySQL server, the installation continue without error.

With `$link = new mysqli(...)`, if the connection fails, `$link` will still contain an empty mysqli object. Thus, we need to explicitly check for errors with `$link->connect_errno`.
