### PR TITLE
Level and duration fields are inverted during the update of challenges

### DIFF
--- a/admin/model/class.ChallengeBackend.php
+++ b/admin/model/class.ChallengeBackend.php
@@ -54,7 +54,7 @@ class ChallengeBackend extends Challenge {
 		}
 	}
 
-	public static function updateChallenge($id,$title,$description,$visibility,$publish, $availability,$duration,$level){
+	public static function updateChallenge($id,$title,$description,$visibility,$publish, $availability, $level, $duration) {
 		global $db;
 		$params = array(':id' => $id,':title' => $title,':description' => $description,
 			            ':visibility' => $visibility,':publish' => $publish,':availability'=>$availability,


### PR DESCRIPTION
Everything is in the title: if you try to change the duration of a challenge for example, it will change the `default_points` field.

While I'm at it, why don't we pass a `Challenge` object to `updateDescription` instead of all the fields?
