### PR TITLE
Fix #84: delete challenges

### DIFF
--- a/admin/controller/class.ChallengeManagerController.php
+++ b/admin/controller/class.ChallengeManagerController.php
@@ -42,7 +42,7 @@ class ChallengeManagerController extends HackademicBackendController {
 		if (isset($_GET["action"]) && ($_GET["action"]=="del")) {
 			$id=$_GET['id'];
 			$challenge=ChallengeBackend::getChallenge($id);
-			$pkg_name=$challenge[0]->pkg_name;
+			$pkg_name = $challenge->pkg_name;
 			self::rrmdir(HACKADEMIC_PATH."challenges/".$pkg_name);
 			ChallengeBackend::deleteChallenge($id);
 			$this->addSuccessMessage("Challenge has been deleted succesfully");


### PR DESCRIPTION
This PR fixes #84.
I don't know why there was a `[0]` so I can't be sure I didn't break something... From my understanding, `CHallengeBackend::getChallenge` takes an ID so it should return only one challenge in all cases...
