### PR TITLE
Fix default class_id parameter for isChallengeCleared

### DIFF
--- a/model/common/class.ChallengeAttempts.php
+++ b/model/common/class.ChallengeAttempts.php
@@ -134,7 +134,7 @@ class ChallengeAttempts {
 		return $result_array;
 	}
 
-	public static function isChallengeCleared($user_id, $challenge_id, $class_id = '*') {
+	public static function isChallengeCleared($user_id, $challenge_id, $class_id = '%') {
 		global $db;
 		$params = array(
 			':user_id' => $user_id,
@@ -144,7 +144,7 @@ class ChallengeAttempts {
 		$sql = "SELECT * FROM challenge_attempts
 				WHERE user_id = :user_id
 				AND	challenge_id = :challenge_id
-				AND class_id = :class_id
+				AND class_id LIKE :class_id
 				AND status = 1;";
 		$query = $db->read($sql, $params, self::$action_type);
 		if ($db->numRows($query)) {


### PR DESCRIPTION
`ChallengeAttempts::isChallengeCleared()` uses '*' as a default value for the `class_id` parameter. This wildcard operator only works with `LIKE`.

The second commit fixes this. The first one sets the same end lines for the whole file.
Before this PR, this file seemed to have several kind of end lines. I didn't manage to edit the file without changing them (they seem to change automatically under Windows as well as under Linux). I made two commits to allow you to see just my fix in the second one.
I came across this issue of heterogeneous end lines in several file.

EDIT: The default value should also be `%` not `*`.
