### PR TITLE
Fix error with multiline gettext translations

### DIFF
--- a/admin/view/editcode.tpl
+++ b/admin/view/editcode.tpl
@@ -11,9 +11,7 @@
                 <tr>
                     <td>
                         <label for="name">
-                            {t}This section allows you to only edit the challenge index.php file.
-                            To edit other parts of the challenge, its recommended that you download the challenge,
-                            and reupload it once you have made the necessary changes.{/t}
+                            {t}EDIT_INSTRUCTIONS_CHALLENGE{/t}
                         </div>
                     </td>
                 </tr>

--- a/locale/en/english.pot
+++ b/locale/en/english.pot
@@ -1,0 +1,12 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8\n"
+
+#: admin/view/editcode.tpl:14
+msgid "EDIT_INSTRUCTIONS_CHALLENGE"
+msgstr "This section allows you to only edit the challenge index.php file.\n"
+"To edit other parts of the challenge, its recommended that you download the challenge,"
+" and reupload it once you have made the necessary changes."
+
+#: view/user_login.tpl:1
+msgid "HELLO_WORLD"
+msgstr "Hello World!"


### PR DESCRIPTION
This should fix the issue with the English text on several lines.