### PR TITLE
141 ranking bug - handle equal ranking score

### DIFF
--- a/controller/class.RankingsController.php
+++ b/controller/class.RankingsController.php
@@ -42,9 +42,9 @@ class RankingsController extends HackademicController {
     private static $action_type = 'rankings';
    
     static  function sort_count($rankA, $rankB) {
-	if ($rankA['score'] == $rankB['score']) {
-			return 0;
-	}
+        if ($rankA['score'] == $rankB['score']) {
+            return ($rankA['last_successful_attempt'] > $rankB['last_successful_attempt']) ? 1 : -1;
+        }
         return ($rankA['score'] < $rankB['score']) ? 1 : -1;
     }
    
@@ -57,10 +57,10 @@ class RankingsController extends HackademicController {
             } else {
                 $user = User::findByUserName($username);
                 $classes = ClassMemberships::getMembershipsOfUserObjects($user->id);
-		$show_global_rankings = new Classes();
-		$show_global_rankings->id = "";
-		$show_global_rankings->name = "Show Universal Rankings";
-		array_unshift($classes, $show_global_rankings);
+        $show_global_rankings = new Classes();
+        $show_global_rankings->id = "";
+        $show_global_rankings->name = "Show Universal Rankings";
+        array_unshift($classes, $show_global_rankings);
             }
             $this->addToView('classes', $classes);
         }
@@ -78,8 +78,8 @@ class RankingsController extends HackademicController {
             }
         }
        usort($rankings, array("RankingsController", "sort_count"));
-	$this->addToView('rankings', $rankings);
+    $this->addToView('rankings', $rankings);
         $this->addSuccessMessage("Showing Active Users Only");
-	return $this->generateView(self::$action_type);
+    return $this->generateView(self::$action_type);
     }
 }

--- a/model/common/class.ChallengeAttempts.php
+++ b/model/common/class.ChallengeAttempts.php
@@ -338,7 +338,7 @@ class ChallengeAttempts {
  
 		$params = array(':class_id'=>$class_id);
 		
-		$challenges_cleared = "SELECT COUNT(DISTINCT challenge_id) as count FROM challenge_attempts WHERE user_id=:user_id AND class_id=:class_id AND status=1";
+		$challenges_cleared = "SELECT COUNT(DISTINCT challenge_id) as count FROM challenge_attempts, MAX(time) as last_successful_attempt WHERE user_id=:user_id AND class_id=:class_id AND status=1";
 		
 		$active = $db->read($active_class_users,$params,self::$action_type);
 		$active_users = array();
@@ -359,8 +359,9 @@ class ChallengeAttempts {
 			$cc = $db->read($challenges_cleared,$params,self::$action_type);
 			while($row = $db->fetchArray($cc)){
 				$cleared_count = $row["count"];
+				$last_successful_attempt=$row['last_successful_attempt'];
 			}
-			array_push($res_score,["id"=>$uinfo['user_id'],'username'=>$username,'score'=>$points,'count'=>$cleared_count]);
+			array_push($res_score,["id"=>$uinfo['user_id'],'username'=>$username,'score'=>$points,'count'=>$cleared_count,'last_successful_attempt'=>$last_successful_attempt]);
 		}
 		return $res_score;
 	}


### PR DESCRIPTION
missing part of the #141 issue (The user who solves a challenge first should be ranked before another who solved the same after him. )

Because ranking is not about one challenge, but about summary, I've made it by checking last successful attempt to any challenge. So if two users have the same score, the user who has finished earlier has better ranking :)