### PR TITLE
fix showing cache notices in input value username, name and email

### DIFF
--- a/controller/class.RegisterUserController.php
+++ b/controller/class.RegisterUserController.php
@@ -91,7 +91,10 @@ class RegisterUserController extends HackademicController {
 					$this->addSuccessMessage("You have been registered succesfully");
 				}
 			}
+		}else{
+			$this->addToView('cached', $this);
 		}
+		
 		return $this->generateView(self::$action_type);
 	}
 

--- a/view/register_user.tpl
+++ b/view/register_user.tpl
@@ -10,17 +10,17 @@
 	<table class="user_add">
 	    <tr>
 		<td><label for="name"> Username </label></td>
-		<td><input type="text" name="username" value="{$cached->username}"/></td>
+		<td><input type="text" name="username" value="{if isset($cached->username)}{$cached->username}{/if}"/></td>
 	    </tr>
 	    
 	    <tr>
 		<td><label> Full Name </label></td>
-		<td><input type="text" name="full_name" value="{$cached->name}"/></td>
+		<td><input type="text" name="full_name" value="{if isset($cached->name)}{$cached->name}{/if}"/></td>
 	    </tr>
 	    
 	    <tr>
 		<td><label> Email </label></td>
-		<td><input type="text" name="email" id="email" value="{$cached->email}"/></td>
+		<td><input type="text" name="email" id="email" value="{if isset($cached->email)}{$cached->email}{/if}"/></td>
 	    </tr>
 	    
 	    <tr>

--- a/view/register_user.tpl
+++ b/view/register_user.tpl
@@ -10,17 +10,17 @@
 	<table class="user_add">
 	    <tr>
 		<td><label for="name"> Username </label></td>
-		<td><input type="text" name="username" value="{if isset($cached->username)}{$cached->username}{/if}"/></td>
+		<td><input type="text" name="username" value="{$cached->username}"/></td>
 	    </tr>
 	    
 	    <tr>
 		<td><label> Full Name </label></td>
-		<td><input type="text" name="full_name" value="{if isset($cached->name)}{$cached->name}{/if}"/></td>
+		<td><input type="text" name="full_name" value="{$cached->name}"/></td>
 	    </tr>
 	    
 	    <tr>
 		<td><label> Email </label></td>
-		<td><input type="text" name="email" id="email" value="{if isset($cached->email)}{$cached->email}{/if}"/></td>
+		<td><input type="text" name="email" id="email" value="{$cached->email}"/></td>
 	    </tr>
 	    
 	    <tr>


### PR DESCRIPTION
there were a problem when creating new account and $cached has not been initialized yet, there where php notices ( <br /><b>Notice</b>:  Undefined index: cached in...) in inputs instead of empty strings. The simple way is to check if they (ie. $cached->name) are set :)